### PR TITLE
Run `ember server` instead of `ember fastboot` in tests

### DIFF
--- a/lib/tests/setup.js
+++ b/lib/tests/setup.js
@@ -16,11 +16,42 @@ function setupTestsForFastboot(appName, options) {
       .then((app) => {
         let port = app.port;
 
-        this.visit = function(route) {
-          let url = `http://localhost:${port}${route}`;
-          debug(`visiting ${url}`);
-          return visit(url);
+        this.visit = function(requestOptions) {
+          let url = requestOptions;
+          if (typeof requestOptions === 'object') {
+            url = requestOptions.uri || requestOptions.url;
+
+            if (requestOptions.headers
+              && requestOptions.headers.Accept
+              && requestOptions.headers.Accept.indexOf('text/html')) {
+              throw new Error('Accept header must include \'text/html\'');
+            }
+          }
+          if (typeof url === 'undefined') {
+            throw new Error('visit helper was called without URL. Either pass a string or an object containing an `url` key.');
+          }
+
+          if (!url.match(/^https?:\/\//)) {
+            let host = `http://localhost:${port}`;
+            let separator = url.charAt(0) === '/' ? '' : '/';
+            url = host + separator + url;
+          }
+
+          requestOptions = Object.assign({}, typeof requestOptions === 'object' ? requestOptions : {}, { url });
+          delete requestOptions.uri;
+          requestOptions.headers = requestOptions.headers || {};
+          if (!requestOptions.headers.Accept) {
+            // We have to send the `Accept` header so the ember-cli server sees this as a request to `index.html` and sets
+            // `req.serveUrl`, that ember-cli-fastboot needs in its middleware
+            // See https://github.com/ember-cli/ember-cli/blob/master/lib/tasks/server/middleware/history-support/index.js#L55
+            // and https://github.com/ember-fastboot/ember-cli-fastboot/blob/master/index.js#L160
+            requestOptions.headers.Accept = 'text/html';
+          }
+
+          debug(`visiting ${url}`, requestOptions);
+          return visit(requestOptions);
         };
+
       });
   });
 }

--- a/lib/tests/visit.js
+++ b/lib/tests/visit.js
@@ -11,8 +11,8 @@ jsdom.defaultDocumentFeatures = {
   ProcessExternalResources: false
 };
 
-function visit(url) {
-  return request(url)
+function visit(opts) {
+  return request(opts)
     .then(function(response) {
       let doc = jsdom.jsdom(response.body);
       let window = doc.defaultView;

--- a/lib/util/app-manager.js
+++ b/lib/util/app-manager.js
@@ -46,13 +46,7 @@ class AppManager {
       })
       .then(function() {
         debug(`Starting FastBoot test app "${appName}" at port ${port}`);
-        let additionalArguments = [];
-        if (options.serveAssets) {
-          additionalArguments.push('--serve-assets');
-        }
         return app.startServer({
-          command: 'fastboot',
-          additionalArguments,
           port
         });
       })

--- a/lib/util/config.js
+++ b/lib/util/config.js
@@ -11,8 +11,7 @@ module.exports = {
     fixturesPath: 'fastboot-tests/fixtures',
     timeout: 600000,
     appName: 'fastboot',
-    port: 49741,
-    serveAssets: false
+    port: 49741
   },
   
   setOption(key, value) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5059,13 +5059,13 @@ signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
-silent-error@^1.0.0, silent-error@^1.0.1:
+silent-error@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/silent-error/-/silent-error-1.0.1.tgz#71b7d503d1c6f94882b51b56be879b113cb4822c"
   dependencies:
     debug "^2.2.0"
 
-silent-error@^1.1.0:
+silent-error@^1.0.1, silent-error@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/silent-error/-/silent-error-1.1.0.tgz#2209706f1c850a9f1d10d0d840918b46f26e1bc9"
   dependencies:


### PR DESCRIPTION
`ember fastboot` is deprecated. Also workaround for https://github.com/ember-fastboot/ember-cli-fastboot/issues/386

Requires at least `ember-cli-fastboot@1.0.0-beta.17`. 
