### PR TITLE
POC to try and get link as the last step in the process

### DIFF
--- a/lib/util/app-manager.js
+++ b/lib/util/app-manager.js
@@ -42,7 +42,8 @@ class AppManager {
           .then(() => {
             // run default blueprints of installed packages
             return RSVP.all(Object.keys(packages).map((pkgName) => app.runEmberCommand('generate', pkgName).catch(() => {})));
-          });
+          })
+          .then(() => app.link(appName));
       })
       .then(function() {
         debug(`Starting FastBoot test app "${appName}" at port ${port}`);

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "chalk": "^1.1.3",
     "core-object": "^2.0.6",
     "debug": "^2.2.0",
-    "ember-cli-addon-tests": "^0.9.2",
+    "ember-cli-addon-tests": "stonecircle/ember-cli-addon-tests#feature/link-as-last-step",
     "ember-router-generator": "^1.2.2",
     "fs-extra": "^0.30.0",
     "jquery": "^3.1.0",


### PR DESCRIPTION
This is related to https://github.com/kaliber5/ember-fastboot-addon-tests/issues/21 and https://github.com/tomdale/ember-cli-addon-tests/issues/176 and is a demo of what I was trying to achieve in https://github.com/tomdale/ember-cli-addon-tests/pull/186

The idea is that because this addon does some work with npm after the initial app is created it needs to be able to execute the machinery of the linking process later in the pipeline. This example doesn't actually work but it gets the point across (I think!)